### PR TITLE
Add Signal logo to sponsor section

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,6 +670,17 @@ title: Supporting the Diversity of Clojure
   <section class="module content">
 
     <div class="row supporter-area">
+      <h2>
+        Sponsors
+      </h2>
+      <div class="col-md-12 supporter-logos">
+        <a href="https://www.signal-ai.com" target="_blank" title="Signal" height="64">
+          <img class="supporter-logo" src="https://www.signal-ai.com/wp-content/themes/signal/assets/img/logo.svg" alt="Signal logo">
+        </a>
+      </div>
+    </div>
+
+    <div class="row supporter-area">
       <h2>Previous Sponsors
       </h2>
       <div class="col-md-12 supporter-logos">


### PR DESCRIPTION
Added Signal logo and link to signal-ai.com as the main sponsor of the event.